### PR TITLE
Fix DataGrid binding and replace unsupported StatusBar

### DIFF
--- a/App.axaml
+++ b/App.axaml
@@ -2,6 +2,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="RNNoise_Denoiser.App">
     <Application.Styles>
-        <FluentTheme Mode="Light"/>
+        <FluentTheme/>
     </Application.Styles>
 </Application>

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -110,16 +110,12 @@
         </DataGrid>
 
         <!-- Status bar -->
-        <StatusBar DockPanel.Dock="Bottom" Name="statusStrip">
-            <StatusBarItem>
+        <Border DockPanel.Dock="Bottom" Name="statusStrip" Padding="4">
+            <DockPanel>
+                <ComboBox Name="cboLang" Width="120" DockPanel.Dock="Right"/>
+                <TextBlock Name="tslMadeBy" Text="Made by timasich" DockPanel.Dock="Right"/>
                 <TextBlock Name="tslStatus" Text="Ready"/>
-            </StatusBarItem>
-            <StatusBarItem HorizontalAlignment="Right">
-                <ComboBox Name="cboLang" Width="120"/>
-            </StatusBarItem>
-            <StatusBarItem HorizontalAlignment="Right">
-                <TextBlock Name="tslMadeBy" Text="Made by timasich"/>
-            </StatusBarItem>
-        </StatusBar>
+            </DockPanel>
+        </Border>
     </DockPanel>
 </Window>

--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -42,7 +42,7 @@ public partial class MainWindow : Window
         btnModelBrowse.Click += BtnModelBrowse_Click;
         btnOutputBrowse.Click += BtnOutputBrowse_Click;
 
-        dgQueue.Items = _queue;
+        dgQueue.ItemsSource = _queue;
     }
 
     async void BtnFfmpegBrowse_Click(object? sender, RoutedEventArgs e)
@@ -85,7 +85,7 @@ public partial class MainWindow : Window
             cboBitrate.Items.Add(br);
         cboBitrate.SelectedItem = _settings.AudioBitrate;
 
-        numMix.Value = _settings.Profile.Mix;
+        numMix.Value = (decimal)_settings.Profile.Mix;
         chkHighpass.IsChecked = _settings.Profile.HighpassHz.HasValue;
         numHighpass.Value = _settings.Profile.HighpassHz ?? 80;
         numHighpass.IsEnabled = chkHighpass.IsChecked == true;
@@ -103,7 +103,7 @@ public partial class MainWindow : Window
         _settings.OutputFolder = txtOutput.Text;
         _settings.AudioCodec = (string?)cboAudioCodec.SelectedItem ?? "aac";
         _settings.AudioBitrate = (string?)cboBitrate.SelectedItem ?? "192k";
-        _settings.Profile.Mix = numMix.Value ?? 0.85;
+        _settings.Profile.Mix = (double)(numMix.Value ?? 0.85m);
         _settings.Profile.HighpassHz = chkHighpass.IsChecked == true ? (int?)numHighpass.Value : null;
         _settings.Profile.LowpassHz = chkLowpass.IsChecked == true ? (int?)numLowpass.Value : null;
         _settings.Profile.SpeechNorm = chkSpeechNorm.IsChecked == true;


### PR DESCRIPTION
## Summary
- bind queue to `DataGrid` using `ItemsSource`
- cast mix value between decimal and double when loading and saving settings
- drop unsupported `Mode` attribute from `FluentTheme`
- replace unsupported `StatusBar` with a simple `DockPanel` layout

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ce9fbbfc832ab0cf6dd2d7cf34b6