### PR TITLE
Improve environment checks and processing

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -97,8 +97,17 @@
             </Grid>
         </Grid>
 
+        <!-- Status bar -->
+        <Border DockPanel.Dock="Bottom" Name="statusStrip" Padding="4">
+            <DockPanel>
+                <ComboBox Name="cboLang" Width="120" DockPanel.Dock="Right"/>
+                <TextBlock Name="tslMadeBy" Text="Made by timasich" DockPanel.Dock="Right"/>
+                <TextBlock Name="tslStatus" Text="Ready"/>
+            </DockPanel>
+        </Border>
+
         <!-- Queue -->
-        <DataGrid Grid.Row="1" Name="dgQueue" AutoGenerateColumns="False">
+        <DataGrid Name="dgQueue" AutoGenerateColumns="False">
             <DataGrid.Columns>
                 <DataGridCheckBoxColumn Binding="{Binding IsChecked}" Width="30"/>
                 <DataGridTextColumn Header="File" Binding="{Binding Input}" Width="480"/>
@@ -108,14 +117,5 @@
                 <DataGridTextColumn Header="Output" Binding="{Binding Output}" Width="320"/>
             </DataGrid.Columns>
         </DataGrid>
-
-        <!-- Status bar -->
-        <Border DockPanel.Dock="Bottom" Name="statusStrip" Padding="4">
-            <DockPanel>
-                <ComboBox Name="cboLang" Width="120" DockPanel.Dock="Right"/>
-                <TextBlock Name="tslMadeBy" Text="Made by timasich" DockPanel.Dock="Right"/>
-                <TextBlock Name="tslStatus" Text="Ready"/>
-            </DockPanel>
-        </Border>
     </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- Show status of ffmpeg, ffprobe, arnndn filter and model in an Environment popup
- Add tooltips to all controls and labels and auto-select Standard preset on startup
- Fix audio processing/preview argument handling and make file queue grid visible

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c087cbc0832a98457929138f8877